### PR TITLE
Passing empty string arguments Issue #3

### DIFF
--- a/clustercheck
+++ b/clustercheck
@@ -13,8 +13,8 @@ if [[ $1 == '-h' || $1 == '--help' ]];then
     exit
 fi
 
-MYSQL_USERNAME="${1:-clustercheckuser}"
-MYSQL_PASSWORD="${2:-clustercheckpassword!}"
+MYSQL_USERNAME="${1-clustercheckuser}"
+MYSQL_PASSWORD="${2-clustercheckpassword!}"
 AVAILABLE_WHEN_DONOR=${3:-0}
 ERR_FILE="${4:-/dev/null}"
 #Timeout exists for instances where mysqld may be hung


### PR DESCRIPTION
The possibility to have mysql credentials as a parameter is a great idea but in our case, we want to use credentials stored in my.cnf.
Because ${1:-default} treat an empty string argument as non-valid, this cases are impossible at this time:

```
# Lease empty in order to mysql uses my.cnf to credentials
clustercheck "" ""
```

```
# User clustercheck with empty password
clustercheck "clustercheck" ""
```

I don't know what solution would be the most elegant... Any idea?

(sorry for the duplicate issue, I'm a Github newbie)
