### PR TITLE
Add a way to manually disable the node

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ Note: You can also specify the username and password for the check in the **defa
 
 ## Manually removing a node from the cluster ##
 
-By touching /var/run/clustercheck.disabled, an admin may force clustercheck to return 503, regardless as to the actual state of the node. This is useful when the node is being put into maintenance mode.
+By touching /var/tmp/clustercheck.disabled, an admin may force clustercheck to return 503, regardless as to the actual state of the node. This is useful when the node is being put into maintenance mode.

--- a/clustercheck
+++ b/clustercheck
@@ -17,7 +17,7 @@ fi
 
 # if the disabled file is present, return 503. This allows
 # admins to manually remove a node from a cluster easily.
-if [ -e "/var/run/clustercheck.disabled" ]; then
+if [ -e "/var/tmp/clustercheck.disabled" ]; then
     # Shell return-code is 1
     echo -en "HTTP/1.1 503 Service Unavailable\r\n"
     echo -en "Content-Type: text/plain\r\n"


### PR DESCRIPTION
By dropping a file into /var/tmp the node can be manually removed from the cluster. This enables a simple way to remove a node from the cluster for maintenance.
