### PR TITLE
Added support for checking defined host

### DIFF
--- a/clustercheck
+++ b/clustercheck
@@ -52,6 +52,9 @@ fi
 if [[ -n "$MYSQL_PASSWORD" ]]; then
     EXTRA_ARGS="$EXTRA_ARGS --password=${MYSQL_PASSWORD}"
 fi
+if [[ -n "$MYSQL_HOST" ]]; then
+    EXTRA_ARGS="$EXTRA_ARGS --host=${MYSQL_HOST}"
+fi
 if [[ -r $DEFAULTS_EXTRA_FILE ]];then
     MYSQL_CMDLINE="mysql --defaults-extra-file=$DEFAULTS_EXTRA_FILE -nNE --connect-timeout=$TIMEOUT \
                     ${EXTRA_ARGS}"


### PR DESCRIPTION
I'm running MariaDB in docker, so I had to specify `-h 127.0.0.1` when connecting from the host. This change adds an option for a specific host and not only the local socket.